### PR TITLE
Update SemanticChatMemoryItem.cs

### DIFF
--- a/webapi/Skills/ChatSkills/SemanticChatMemoryItem.cs
+++ b/webapi/Skills/ChatSkills/SemanticChatMemoryItem.cs
@@ -38,6 +38,6 @@ public class SemanticChatMemoryItem
     /// <returns>A formatted string representing the item.</returns>
     public string ToFormattedString()
     {
-        return $"{this.Label}: {this.Details.Trim()}";
+        return $"{this.Label}: {this.Details?.Trim()}";
     }
 }


### PR DESCRIPTION
Fix null reference in ToFormattedString function

In the `SemanticChatMemoryItem.ToFormattedString` function, ensure that the `Details` property is not null before trimming it. This change prevents potential NullReferenceExceptions when the `Details` property is null.

This modification ensures the stability of the `ToFormattedString` function when used in other parts of the code.

### Motivation and Context

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
